### PR TITLE
[src] Update Grasper Jaw to link with an existing SpringFF instead of creating it. Seems not to well handle topological changes

### DIFF
--- a/src/InfinyToolkit/InteractionTools/GrasperJawModel.h
+++ b/src/InfinyToolkit/InteractionTools/GrasperJawModel.h
@@ -54,16 +54,15 @@ public:
 	void performSecondaryAction() override;
 	/// Main API public method to stop the action of the Jaw
 	void stopSecondaryAction() override;
-
+	
 	Data<SReal> d_stiffness;
+	SingleLink<GrasperJawModel, SpringFF, BaseLink::FLAG_STOREPATH | BaseLink::FLAG_STRONGLINK> l_springFF;
 
 protected:
 	bool initImpl() override;
 	int createStiffSpringFF();
 	void addJawSprings();
 
-private:
-	SpringFF::SPtr m_forcefield = nullptr;
 };
 					
 } // namespace sofa::infinytoolkit


### PR DESCRIPTION
This way it is possible to keep tissue grasped while cutting it. The spring are well renumbered.

Not very clear why the created SpringFF was not supported topological changes

https://github.com/user-attachments/assets/3ca1cfa0-7e7a-4ff9-86a3-a6e588d3e1ba

